### PR TITLE
Fix `severity_level` in 7.x branch

### DIFF
--- a/logs_http.module
+++ b/logs_http.module
@@ -136,7 +136,8 @@ function logs_http_register_event(array $log_entry) {
     'uid' => $log_entry['uid'],
     'link' => strip_tags($log_entry['link']),
     'message' => empty($log_entry['variables']) ? $log_entry['message'] : strtr($log_entry['message'], $log_entry['variables']),
-    'severity' => $log_entry['severity'],
+    'severity' => watchdog_severity_levels()[$log_entry['severity']],
+    'severity_level' => $log_entry['severity'],
   );
 
   if (!empty($log_entry['variables']['exception_trace'])) {


### PR DESCRIPTION
In this branch everything is set up properly, only the severity is returned as an integer. To match it with Drupal 8.x branch, I renamed the `severity` to `severity_level` and fetched the string using the ENUM from watchdog_security_levels() function.